### PR TITLE
Fixed the bug!

### DIFF
--- a/challenge/index.ts
+++ b/challenge/index.ts
@@ -1,5 +1,6 @@
 import algosdk from "algosdk";
 import * as algokit from '@algorandfoundation/algokit-utils';
+import { SigningAccount } from "@algorandfoundation/algokit-utils/types/account"
 
 // Set up algod client
 const algodClient = algokit.getAlgoClient()
@@ -42,9 +43,11 @@ const ptxn2 = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
     amount: 2000000, // 2 ALGOs
 });
 
+const txnSigner = new SigningAccount(sender, sender.addr).signer
+
 const atc = new algosdk.AtomicTransactionComposer()
-atc.addTransaction({txn: ptxn1, signer: sender})
-atc.addTransaction({txn: ptxn2, signer: sender})
+atc.addTransaction({txn: ptxn1, signer: txnSigner})
+atc.addTransaction({txn: ptxn2, signer: txnSigner})
 
 const result = await algokit.sendAtomicTransactionComposer({atc:atc, sendParams: {suppressLog:true}}, algodClient)
 console.log(`The first payment transaction sent ${result.transactions[0].amount} microAlgos and the second payment transaction sent ${result.transactions[1].amount} microAlgos`)


### PR DESCRIPTION
## Fix the Bug Submission Pull Request

**What was the bug?**

When adding transactions to the atomic transaction composer, we need to provide an `algosdk.TransactionSigner` that can sign the transactions.

**How did you fix the bug?**

I created a `TransactionSigner` by creating a new `SigningAccount` class from the sender account which was initialized above.  This class provides a getter `signer()` which returns a `TransactionSigner` that can be provided to the atomic transaction composer.  Setting this as the signer property resolved the bug.

**Console Screenshot:**

<img width="819" alt="image" src="https://github.com/algorand-coding-challenges/challenge-4/assets/20627143/cf412315-b51c-4ef7-a56e-4f22479350eb">