### PR TITLE
Fixed the bug! 

### DIFF
--- a/challenge/index.ts
+++ b/challenge/index.ts
@@ -42,9 +42,11 @@ const ptxn2 = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
     amount: 2000000, // 2 ALGOs
 });
 
+const senderSigner = algosdk.makeBasicAccountTransactionSigner(sender)
+
 const atc = new algosdk.AtomicTransactionComposer()
-atc.addTransaction({txn: ptxn1, signer: sender})
-atc.addTransaction({txn: ptxn2, signer: sender})
+atc.addTransaction({txn: ptxn1, signer: senderSigner})
+atc.addTransaction({txn: ptxn2, signer: senderSigner})
 
 const result = await algokit.sendAtomicTransactionComposer({atc:atc, sendParams: {suppressLog:true}}, algodClient)
 console.log(`The first payment transaction sent ${result.transactions[0].amount} microAlgos and the second payment transaction sent ${result.transactions[1].amount} microAlgos`)


### PR DESCRIPTION
## Fix the Bug Submission Pull Request

**What was the bug?**

The error when running the file before fixing the bug showed: "TypeError: signer is not a function" This means inside the atc.addTransaction part it was not recognising the signer of the transactions.

**How did you fix the bug?**

I remember going through a very similar code during one of the teaching sessions from the dev-rel team, and I noticed I had to instantiate a signer. I fixed the bug by creating a signer with the algosdk makeBasicAccountTransactionSigner Function. I then passed the sender account through the parameters and I called this with the variable name senderSigner. I then replaced the sender for the senderSigner within the atc transactions.
Basically like so:

**const senderSigner = algosdk.makeBasicAccountTransactionSigner(sender)**
...
atc.addTransaction({txn: ptxn1, signer: **senderSigner**})

**Console Screenshot:**

<img width="659" alt="image" src="https://github.com/algorand-coding-challenges/challenge-4/assets/127313669/b8c40930-f15b-4642-81ec-4510b9261555">