### PR TITLE
atc transactions sent

### DIFF
--- a/challenge/index.ts
+++ b/challenge/index.ts
@@ -43,8 +43,9 @@ const ptxn2 = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
 });
 
 const atc = new algosdk.AtomicTransactionComposer()
-atc.addTransaction({txn: ptxn1, signer: sender})
-atc.addTransaction({txn: ptxn2, signer: sender})
+const signer = algosdk.makeBasicAccountTransactionSigner(sender)
+atc.addTransaction({txn: ptxn1, signer: signer})
+atc.addTransaction({txn: ptxn2, signer: signer})
 
 const result = await algokit.sendAtomicTransactionComposer({atc:atc, sendParams: {suppressLog:true}}, algodClient)
 console.log(`The first payment transaction sent ${result.transactions[0].amount} microAlgos and the second payment transaction sent ${result.transactions[1].amount} microAlgos`)

--- a/challenge/package-lock.json
+++ b/challenge/package-lock.json
@@ -1,10 +1,10 @@
 {
-  "name": "algorand-puzzle-1",
+  "name": "algorand-puzzle-4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "algorand-puzzle-1",
+      "name": "algorand-puzzle-4",
       "dependencies": {
         "@algorandfoundation/algokit-utils": "^5.8.0",
         "algosdk": "^2.7.0",

--- a/challenge/package.json
+++ b/challenge/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "algorand-puzzle-1",
+  "name": "algorand-puzzle-4",
   "module": "index.ts",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Fix the Bug Submission Pull Request

**What was the bug?**
atc.addTransaction({txn: ptxn1, signer: sender})
atc.addTransaction({txn: ptxn2, signer: sender})

property signer can not be assigned by sender, type error

The warning given by VS Code is:
Type 'Account' is not assignable to type 'TransactionSigner'.
 Type 'Account' provides no match for the signature '(txnGroup: Transaction[], indexesToSign: number[]): Promise<Uint8Array[]>'.ts(2322)
signer.d.ts(38, 5): The expected type comes from property 'signer' which is declared here on type 'TransactionWithSigner'
(property) TransactionWithSigner.signer: algosdk.TransactionSigner
A transaction signer that can authorize txn

**How did you fix the bug?**
Opening signer.d.ts, I found the following function
export declare function makeBasicAccountTransactionSigner(account: Account): TransactionSigner;
Using that function, I created a signer, and used that signer in atc.addTransaction:

const signer = algosdk.makeBasicAccountTransactionSigner(sender)
atc.addTransaction({txn: ptxn1, signer: signer})
atc.addTransaction({txn: ptxn2, signer: signer})

**Console Screenshot:**
<img width="1920" alt="challenge-4" src="https://github.com/algorand-coding-challenges/challenge-4/assets/58363638/267a5cd2-42af-4ca2-a437-3251df2b7bb4">
