### PR TITLE
Fix Atc: Bad addTransaction parameter type.

### DIFF
--- a/challenge/index.ts
+++ b/challenge/index.ts
@@ -6,6 +6,7 @@ const algodClient = algokit.getAlgoClient()
 
 // Retrieve 2 accounts from localnet kmd
 const sender = await algokit.getLocalNetDispenserAccount(algodClient)
+const signer = algokit.getSenderTransactionSigner(sender)
 
 const receiver = await algokit.mnemonicAccountFromEnvironment(
     {name: 'RECEIVER', fundWith: algokit.algos(100)},
@@ -43,8 +44,8 @@ const ptxn2 = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
 });
 
 const atc = new algosdk.AtomicTransactionComposer()
-atc.addTransaction({txn: ptxn1, signer: sender})
-atc.addTransaction({txn: ptxn2, signer: sender})
+atc.addTransaction({txn: ptxn1, signer})
+atc.addTransaction({txn: ptxn2, signer})
 
 const result = await algokit.sendAtomicTransactionComposer({atc:atc, sendParams: {suppressLog:true}}, algodClient)
 console.log(`The first payment transaction sent ${result.transactions[0].amount} microAlgos and the second payment transaction sent ${result.transactions[1].amount} microAlgos`)


### PR DESCRIPTION
## Fix the Bug Submission Pull Request

**What was the bug?**

Incorrect parameter in the addTransaction() methods calls.

**How did you fix the bug?**

With the help of the Algokit lib, I was able to retrieve a **signer** ( getSenderTransactionSigner(<Account>) ).
Then pass the correct signer to the addTransaction() method. 
Voilà !

**Console Screenshot:**

![image](https://github.com/algorand-coding-challenges/challenge-4/assets/5107647/e4e8934d-9c91-4da4-b3a7-98e2a64a1077)