### PR TITLE
fix: add transaction signer

### DIFF
--- a/challenge/index.ts
+++ b/challenge/index.ts
@@ -1,16 +1,17 @@
-import algosdk from "algosdk";
-import * as algokit from '@algorandfoundation/algokit-utils';
+import algosdk, { type TransactionSigner } from "algosdk";
+import * as algokit from "@algorandfoundation/algokit-utils";
+import { SigningAccount } from "@algorandfoundation/algokit-utils/types/account";
 
 // Set up algod client
-const algodClient = algokit.getAlgoClient()
+const algodClient = algokit.getAlgoClient();
 
 // Retrieve 2 accounts from localnet kmd
-const sender = await algokit.getLocalNetDispenserAccount(algodClient)
+const sender = await algokit.getLocalNetDispenserAccount(algodClient);
 
 const receiver = await algokit.mnemonicAccountFromEnvironment(
-    {name: 'RECEIVER', fundWith: algokit.algos(100)},
-    algodClient,
-  )
+  { name: "RECEIVER", fundWith: algokit.algos(100) },
+  algodClient
+);
 
 /*
 TODO: edit code below
@@ -25,27 +26,32 @@ When solved correctly, the console should print out the following:
 "The first payment transaction sent 1000000 microAlgos and the second payment transaction sent 2000000 microAlgos"
 */
 
+const signer: TransactionSigner = new SigningAccount(sender, sender.addr)
+  .signer;
+
 const suggestedParams = await algodClient.getTransactionParams().do();
 const ptxn1 = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
-    from: sender.addr,
-    suggestedParams,
-    to: receiver.addr,
-    amount: 1000000,// 1 ALGO
+  from: sender.addr,
+  suggestedParams,
+  to: receiver.addr,
+  amount: 1000000, // 1 ALGO
 });
-
-/// <reference lib="dom" />
 
 const ptxn2 = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
-    from: sender.addr,
-    suggestedParams,
-    to: receiver.addr,
-    amount: 2000000, // 2 ALGOs
+  from: sender.addr,
+  suggestedParams,
+  to: receiver.addr,
+  amount: 2000000, // 2 ALGOs
 });
 
-const atc = new algosdk.AtomicTransactionComposer()
-atc.addTransaction({txn: ptxn1, signer: sender})
-atc.addTransaction({txn: ptxn2, signer: sender})
+const atc = new algosdk.AtomicTransactionComposer();
+atc.addTransaction({ txn: ptxn1, signer });
+atc.addTransaction({ txn: ptxn2, signer });
 
-const result = await algokit.sendAtomicTransactionComposer({atc:atc, sendParams: {suppressLog:true}}, algodClient)
-console.log(`The first payment transaction sent ${result.transactions[0].amount} microAlgos and the second payment transaction sent ${result.transactions[1].amount} microAlgos`)
-
+const result = await algokit.sendAtomicTransactionComposer(
+  { atc: atc, sendParams: { suppressLog: true } },
+  algodClient
+);
+console.log(
+  `The first payment transaction sent ${result.transactions[0].amount} microAlgos and the second payment transaction sent ${result.transactions[1].amount} microAlgos`
+);


### PR DESCRIPTION
## Fix the Bug Submission Pull Request

**What was the bug?**

The `AtomicTransactionComposer` is expecting valid `TransactionSigner`, but it's receiving an `Account` (`sender`).

**How did you fix the bug?**

1. Created a signer: `const signer: TransactionSigner = new SigningAccount(sender, sender.addr).signer;`
2. Replaced `sender` with `signer` in atomic transactions: e.g. `atc.addTransaction({ txn: ptxn2, signer });`

**Console Screenshot:**

<img width="1840" alt="Screenshot 2024-03-26 at 15 10 46" src="https://github.com/algorand-coding-challenges/challenge-4/assets/145453/2290b6a5-6081-47ff-8559-ff301a492431">

> It's been fun. Hope to see more in the future. 🙏🏾