### PR TITLE
fix: use account transaction signer with addTransaction()

### DIFF
--- a/challenge/index.ts
+++ b/challenge/index.ts
@@ -42,9 +42,11 @@ const ptxn2 = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
     amount: 2000000, // 2 ALGOs
 });
 
+const signer = algosdk.makeBasicAccountTransactionSigner(sender);
+
 const atc = new algosdk.AtomicTransactionComposer()
-atc.addTransaction({txn: ptxn1, signer: sender})
-atc.addTransaction({txn: ptxn2, signer: sender})
+atc.addTransaction({txn: ptxn1, signer})
+atc.addTransaction({txn: ptxn2, signer})
 
 const result = await algokit.sendAtomicTransactionComposer({atc:atc, sendParams: {suppressLog:true}}, algodClient)
 console.log(`The first payment transaction sent ${result.transactions[0].amount} microAlgos and the second payment transaction sent ${result.transactions[1].amount} microAlgos`)


### PR DESCRIPTION
## Fix the Bug Submission Pull Request

**What was the bug?**

Account Transaction Signer object needed as argument when adding TransactionWithSigner objects to AtomicTransactionComposer.

**How did you fix the bug?**

Used algosdk.makeBasicAccountTransactionSigner(sender) to create the transaction signer object and passed in as signer argument. 

**Console Screenshot:**

<img width="480" alt="image" src="https://github.com/algorand-coding-challenges/challenge-4/assets/157974735/88d2b6f8-e648-454a-8431-98a2cba41cf5">