### PR TITLE
Fixed it! Added Signer from algosdk. 

### DIFF
--- a/challenge/index.ts
+++ b/challenge/index.ts
@@ -2,7 +2,7 @@ import algosdk from "algosdk";
 import * as algokit from '@algorandfoundation/algokit-utils';
 
 // Set up algod client
-const algodClient = algokit.getAlgoClient()
+const algodClient = algokit.getAlgoClient();
 
 // Retrieve 2 accounts from localnet kmd
 const sender = await algokit.getLocalNetDispenserAccount(algodClient)
@@ -26,6 +26,7 @@ When solved correctly, the console should print out the following:
 */
 
 const suggestedParams = await algodClient.getTransactionParams().do();
+
 const ptxn1 = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
     from: sender.addr,
     suggestedParams,
@@ -42,9 +43,10 @@ const ptxn2 = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
     amount: 2000000, // 2 ALGOs
 });
 
+const signer = algosdk.makeBasicAccountTransactionSigner(sender);
 const atc = new algosdk.AtomicTransactionComposer()
-atc.addTransaction({txn: ptxn1, signer: sender})
-atc.addTransaction({txn: ptxn2, signer: sender})
+atc.addTransaction({txn: ptxn1, signer: signer})
+atc.addTransaction({txn: ptxn2, signer: signer})
 
 const result = await algokit.sendAtomicTransactionComposer({atc:atc, sendParams: {suppressLog:true}}, algodClient)
 console.log(`The first payment transaction sent ${result.transactions[0].amount} microAlgos and the second payment transaction sent ${result.transactions[1].amount} microAlgos`)


### PR DESCRIPTION
## Fix the Bug Submission Pull Request

**What was the bug?**
Given code was showing error ``TypeError: signer is not a function`` . It indicated that ``atc.addTransaction({ })``  has some errors into it. Simply it was not getting ``signer`` of the transaction.

Account transaction signer object should need to pass as argument while adding it into AtomicTransactionComposer. Property was missing there. 

![Challenge 4 problem](https://github.com/algorand-coding-challenges/challenge-4/assets/107026627/60785efe-383f-4b53-8828-7a833f9e811c)



**How did you fix the bug?**

 I fixed the bug by creating a signer with the algosdk makeBasicAccountTransactionSigner Function. 

``const signer = algosdk.makeBasicAccountTransactionSigner(sender);``



**Console Screenshot:**

![challenge 4](https://github.com/algorand-coding-challenges/challenge-4/assets/107026627/534218cf-e7dd-4e21-9a97-835b2d47e390)


<!-- Attach a screenshot of your console showing the result specified in the README. -->