### PR TITLE
Updated add transaction to use transaction signer instead of account object

### DIFF
--- a/challenge/index.ts
+++ b/challenge/index.ts
@@ -1,4 +1,4 @@
-import algosdk from "algosdk";
+import algosdk, {makeBasicAccountTransactionSigner} from "algosdk";
 import * as algokit from '@algorandfoundation/algokit-utils';
 
 // Set up algod client
@@ -42,9 +42,11 @@ const ptxn2 = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
     amount: 2000000, // 2 ALGOs
 });
 
+const acctTxSender = makeBasicAccountTransactionSigner(sender)
+
 const atc = new algosdk.AtomicTransactionComposer()
-atc.addTransaction({txn: ptxn1, signer: sender})
-atc.addTransaction({txn: ptxn2, signer: sender})
+atc.addTransaction({txn: ptxn1, signer: acctTxSender})
+atc.addTransaction({txn: ptxn2, signer: acctTxSender})
 
 const result = await algokit.sendAtomicTransactionComposer({atc:atc, sendParams: {suppressLog:true}}, algodClient)
 console.log(`The first payment transaction sent ${result.transactions[0].amount} microAlgos and the second payment transaction sent ${result.transactions[1].amount} microAlgos`)


### PR DESCRIPTION
Updated add transaction to use transaction signer instead of account object
## Fix the Bug Submission Pull Request

**What was the bug?**

addTransaction was using an account object instead of a signer object

**How did you fix the bug?**

Created an account transaction signer and then sent the transaction signer instead of the account.

Ran `algokit bootstrap all`
![image](https://github.com/algorand-coding-challenges/challenge-4/assets/4576768/a6381dd3-5ad0-4636-b085-87d422361a6c)

Tried running `npm run start`

Got the following error:
![image](https://github.com/algorand-coding-challenges/challenge-4/assets/4576768/602e2549-e6f3-4148-8e46-124c77bd3422)

I've made the code change that I think is correct here, but not sure what is going above... will try to look for solutions online
