### PR TITLE
Update index.ts

### DIFF
--- a/challenge/index.ts
+++ b/challenge/index.ts
@@ -43,9 +43,11 @@ const ptxn2 = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
 });
 
 const atc = new algosdk.AtomicTransactionComposer()
-atc.addTransaction({txn: ptxn1, signer: sender})
-atc.addTransaction({txn: ptxn2, signer: sender})
+const senderSigner = algosdk.makeBasicAccountTransactionSigner(sender);
+atc.addTransaction({txn: ptxn1, signer: senderSigner});
+atc.addTransaction({txn: ptxn2, signer: senderSigner});
 
 const result = await algokit.sendAtomicTransactionComposer({atc:atc, sendParams: {suppressLog:true}}, algodClient)
 console.log(`The first payment transaction sent ${result.transactions[0].amount} microAlgos and the second payment transaction sent ${result.transactions[1].amount} microAlgos`)
+console.log(`dimzachar`)
 


### PR DESCRIPTION
## Fix the Bug Submission Pull Request

**What was the bug?**

The problem lies in how the `signer` is being specified for the transactions in the `AtomicTransactionComposer`. 
```
atc.addTransaction({txn: ptxn1, signer: sender})
atc.addTransaction({txn: ptxn2, signer: sender})
```
The error message `TypeError: signer is not a function` hints that the signer property is not correctly provided.

Here, `sender` is passed as the signer. However, according to the challenge hints and the Algorand JavaScript SDK, the `signer` should be a function that knows how to sign the transactions, not just the account object itself.


**How did you fix the bug?**

The Algorand JS SDK documentation mentions `makeBasicAccountTransactionSigner`, a utility function that creates a signer function from an account object:

1)Create a signer function for `sender` account using the `makeBasicAccountTransactionSigner` function from the Algorand JavaScript SDK.

2)Pass the created signer function to `atc.addTransaction`

The challenge doesn't specify details about the rekeyed account or its keys, so not sure if we need to take into account if account is rekeyed.

**Console Screenshot:**

![challenge4](https://github.com/algorand-coding-challenges/challenge-4/assets/113017737/cf552ed2-a806-4a3f-a255-afffe4cc8d9e)

