### PR TITLE
Create a basic account transaction signer and use it in addTransaction

### DIFF
--- a/challenge/index.ts
+++ b/challenge/index.ts
@@ -42,9 +42,11 @@ const ptxn2 = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
     amount: 2000000, // 2 ALGOs
 });
 
+const txnSigner = algosdk.makeBasicAccountTransactionSigner(sender);
+
 const atc = new algosdk.AtomicTransactionComposer()
-atc.addTransaction({txn: ptxn1, signer: sender})
-atc.addTransaction({txn: ptxn2, signer: sender})
+atc.addTransaction({txn: ptxn1, signer: txnSigner})
+atc.addTransaction({txn: ptxn2, signer: txnSigner})
 
 const result = await algokit.sendAtomicTransactionComposer({atc:atc, sendParams: {suppressLog:true}}, algodClient)
 console.log(`The first payment transaction sent ${result.transactions[0].amount} microAlgos and the second payment transaction sent ${result.transactions[1].amount} microAlgos`)


### PR DESCRIPTION
## Fix the Bug Submission Pull Request

**What was the bug?**

`atc.addTransaction(...)` was using the sender `Account` instead of a `TransactionSigner` for the provided account. 

**How did you fix the bug?**

Create a `TransactionSigner` for the account by using `algosdk.makeBasicAccountTransactionSigner(sender)` and pass the resulting transaction signer to `addTransaction`.

**Console Screenshot:**

![image](https://github.com/algorand-coding-challenges/challenge-4/assets/1091843/70e84116-603f-42c1-8fdc-a6d422581d62)