### PR TITLE
Challenge 4 Solved

### DIFF
--- a/challenge/index.ts
+++ b/challenge/index.ts
@@ -1,5 +1,6 @@
-import algosdk from "algosdk";
+import algosdk, { type TransactionSigner } from "algosdk";
 import * as algokit from '@algorandfoundation/algokit-utils';
+import { SigningAccount } from "@algorandfoundation/algokit-utils/types/account";
 
 // Set up algod client
 const algodClient = algokit.getAlgoClient()
@@ -42,11 +43,13 @@ const ptxn2 = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
     amount: 2000000, // 2 ALGOs
 });
 
-const senderSigner = algosdk.makeBasicAccountTransactionSigner(sender);
+const signer: TransactionSigner = new SigningAccount(sender, sender.addr)
+    .signer;
+// const senderSigner = algosdk.makeBasicAccountTransactionSigner(sender);
 
 const atc = new algosdk.AtomicTransactionComposer()
-atc.addTransaction({txn: ptxn1, signer: senderSigner})
-atc.addTransaction({txn: ptxn2, signer: senderSigner})
+atc.addTransaction({txn: ptxn1, signer})
+atc.addTransaction({txn: ptxn2, signer})
 
 const result = await algokit.sendAtomicTransactionComposer({atc:atc, sendParams: {suppressLog:true}}, algodClient)
 console.log(`The first payment transaction sent ${result.transactions[0].amount} microAlgos and the second payment transaction sent ${result.transactions[1].amount} microAlgos`)

--- a/challenge/index.ts
+++ b/challenge/index.ts
@@ -42,9 +42,11 @@ const ptxn2 = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
     amount: 2000000, // 2 ALGOs
 });
 
+const senderSigner = algosdk.makeBasicAccountTransactionSigner(sender);
+
 const atc = new algosdk.AtomicTransactionComposer()
-atc.addTransaction({txn: ptxn1, signer: sender})
-atc.addTransaction({txn: ptxn2, signer: sender})
+atc.addTransaction({txn: ptxn1, signer: senderSigner})
+atc.addTransaction({txn: ptxn2, signer: senderSigner})
 
 const result = await algokit.sendAtomicTransactionComposer({atc:atc, sendParams: {suppressLog:true}}, algodClient)
 console.log(`The first payment transaction sent ${result.transactions[0].amount} microAlgos and the second payment transaction sent ${result.transactions[1].amount} microAlgos`)

--- a/challenge/index.ts
+++ b/challenge/index.ts
@@ -45,7 +45,6 @@ const ptxn2 = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
 
 const signer: TransactionSigner = new SigningAccount(sender, sender.addr)
     .signer;
-// const senderSigner = algosdk.makeBasicAccountTransactionSigner(sender);
 
 const atc = new algosdk.AtomicTransactionComposer()
 atc.addTransaction({txn: ptxn1, signer})


### PR DESCRIPTION
## Fix the Bug Submission Pull Request

**What was the bug?**
The bug is from the `AutomicTransactionComposer` expecting a valid `TransactionSigner`, but it is receiving only Account and the Sender. The Signer is assigned with the TransactionSigner with new SigningAccount os that it can be called twice.

**How did you fix the bug?**
added the signer above the `AtomicTransactionComposer`, with new variable  --`const siginer: transactionSigner = new SigningAccount(sender, sender.addr)` and in the Transaction phase, we just need only  signer, so we removed the sender in the `addTransaction`


**Console Screenshot:**
![image](https://github.com/algorand-coding-challenges/challenge-4/assets/79416752/5e08649c-048c-46a1-8e1a-be1ecb82473f)
