### PR TITLE
Algokit Challenge #4 - Completed. 

### DIFF
--- a/challenge/index.ts
+++ b/challenge/index.ts
@@ -13,9 +13,7 @@ const receiver = await algokit.mnemonicAccountFromEnvironment(
   )
 
 /*
-TODO: edit code below
-
-Description: 
+Description:
 The below code is trying to atomically send 2 payment from sender to receiver 
 account by grouping them into an atomic transaction composer. 
 However, the code is not working. find and fix the bug so that the 2 payments are 
@@ -43,8 +41,10 @@ const ptxn2 = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
 });
 
 const atc = new algosdk.AtomicTransactionComposer()
-atc.addTransaction({txn: ptxn1, signer: sender})
-atc.addTransaction({txn: ptxn2, signer: sender})
+// Create a basic account transaction signer with ( sender ) account
+const signer = algosdk.makeBasicAccountTransactionSigner(sender)
+atc.addTransaction({txn: ptxn1, signer: signer})
+atc.addTransaction({txn: ptxn2, signer: signer})
 
 const result = await algokit.sendAtomicTransactionComposer({atc:atc, sendParams: {suppressLog:true}}, algodClient)
 console.log(`The first payment transaction sent ${result.transactions[0].amount} microAlgos and the second payment transaction sent ${result.transactions[1].amount} microAlgos`)


### PR DESCRIPTION
## Fix the Bug Submission Pull Request

**What was the bug?**

1. The problem was the sender account variable was not a makeBasicAccountTransactionSigner function.  The atc.addTransaction function takes in 2 parameters, the transaction and the makeBasicAccountTransactionSigner function with the (sender aka:signer) account.

**How did you fix the bug?**

2. By creating a variable 'signer' and assigning it the makeBasicAccountTransactionSigner with ( sender ) account. Then updated the atc.addTransaction signer values to signer on both of the following lines.

**Console Screenshot:**

![image](https://github.com/algorand-coding-challenges/challenge-4/assets/57732382/54f18790-2ccd-4362-b8dc-9c6b7d69a7f1)