### PR TITLE
Bug Fix: get the signer of sender account

### DIFF
--- a/challenge/index.ts
+++ b/challenge/index.ts
@@ -15,10 +15,10 @@ const receiver = await algokit.mnemonicAccountFromEnvironment(
 /*
 TODO: edit code below
 
-Description: 
-The below code is trying to atomically send 2 payment from sender to receiver 
-account by grouping them into an atomic transaction composer. 
-However, the code is not working. find and fix the bug so that the 2 payments are 
+Description:
+The below code is trying to atomically send 2 payment from sender to receiver
+account by grouping them into an atomic transaction composer.
+However, the code is not working. find and fix the bug so that the 2 payments are
 successfully sent atomically.
 
 When solved correctly, the console should print out the following:
@@ -43,8 +43,9 @@ const ptxn2 = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
 });
 
 const atc = new algosdk.AtomicTransactionComposer()
-atc.addTransaction({txn: ptxn1, signer: sender})
-atc.addTransaction({txn: ptxn2, signer: sender})
+const signer = algosdk.makeBasicAccountTransactionSigner(sender);
+atc.addTransaction({txn: ptxn1, signer: signer})
+atc.addTransaction({txn: ptxn2, signer: signer})
 
 const result = await algokit.sendAtomicTransactionComposer({atc:atc, sendParams: {suppressLog:true}}, algodClient)
 console.log(`The first payment transaction sent ${result.transactions[0].amount} microAlgos and the second payment transaction sent ${result.transactions[1].amount} microAlgos`)


### PR DESCRIPTION
## Fix the Bug Submission Pull Request

**What was the bug?**

The basic sender account can not sign the transactions.

**How did you fix the bug?**

Create a TransactionSigner that can sign transactions for the provided basic account.
const signer = algosdk.makeBasicAccountTransactionSigner(sender);

**Console Screenshot:**

![Bildschirmfoto 2024-03-26 um 22 40 07](https://github.com/algorand-coding-challenges/challenge-4/assets/2846368/51475c3a-848d-47a5-bb0f-a58a6307018d)
