### PR TITLE
solved challenge 4

### DIFF
--- a/challenge/index.ts
+++ b/challenge/index.ts
@@ -43,8 +43,8 @@ const ptxn2 = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
 });
 
 const atc = new algosdk.AtomicTransactionComposer()
-atc.addTransaction({txn: ptxn1, signer: sender})
-atc.addTransaction({txn: ptxn2, signer: sender})
+atc.addTransaction({txn: ptxn1, signer: algosdk.makeBasicAccountTransactionSigner(sender)})
+atc.addTransaction({txn: ptxn2, signer: algosdk.makeBasicAccountTransactionSigner(sender)})
 
 const result = await algokit.sendAtomicTransactionComposer({atc:atc, sendParams: {suppressLog:true}}, algodClient)
 console.log(`The first payment transaction sent ${result.transactions[0].amount} microAlgos and the second payment transaction sent ${result.transactions[1].amount} microAlgos`)


### PR DESCRIPTION
## Fix the Bug Submission Pull Request

**What was the bug?**

`AtomicTransactionComposer#addTransaction` expects a signer with type `TransactionSigner` but received `Account`

**How did you fix the bug?**

Found a function in the algosdk docs to creates a TransactionSigner from an Account https://algorand.github.io/js-algorand-sdk/functions/makeBasicAccountTransactionSigner.html

**Console Screenshot:**
![Screenshot 2024-03-26 at 10 22 17 PM](https://github.com/algorand-coding-challenges/challenge-4/assets/11330507/5353ac52-2bbf-4dc0-87e0-42654dbf94b1)
