### PR TITLE
fix: incorrect signer when adding multiple transactions to atomic transaction composer

### DIFF
--- a/challenge/index.ts
+++ b/challenge/index.ts
@@ -43,8 +43,8 @@ const ptxn2 = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
 });
 
 const atc = new algosdk.AtomicTransactionComposer()
-atc.addTransaction({txn: ptxn1, signer: sender})
-atc.addTransaction({txn: ptxn2, signer: sender})
+atc.addTransaction({txn: ptxn1, signer: algosdk.makeBasicAccountTransactionSigner(sender)})
+atc.addTransaction({txn: ptxn2, signer: algosdk.makeBasicAccountTransactionSigner(sender)})
 
 const result = await algokit.sendAtomicTransactionComposer({atc:atc, sendParams: {suppressLog:true}}, algodClient)
 console.log(`The first payment transaction sent ${result.transactions[0].amount} microAlgos and the second payment transaction sent ${result.transactions[1].amount} microAlgos`)


### PR DESCRIPTION
## Fix the Bug Submission Pull Request

**What was the bug?**

Incorrect parameters for the signer were supplied to the `addTransaction` method of the atomic transaction composer. The method expected a `TransactionSigner` but was provided with a sender `Account`

**How did you fix the bug?**

Created `TransactionSigner` based on the `sender` account and put it in the place of the `sender` value being passed to `addTransaction` on the `AtomicTransactionComposer`

**Console Screenshot:**
<img width="1269" alt="Screenshot 2024-03-26 at 8 23 09 PM" src="https://github.com/algorand-coding-challenges/challenge-4/assets/5781627/5bb87fae-f5de-447b-ac40-644a24277878">

