### PR TITLE
atomic transaction group bugfix

### DIFF
--- a/challenge/index.ts
+++ b/challenge/index.ts
@@ -42,9 +42,11 @@ const ptxn2 = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
     amount: 2000000, // 2 ALGOs
 });
 
+const signer = algokit.getSenderTransactionSigner(sender)
+
 const atc = new algosdk.AtomicTransactionComposer()
-atc.addTransaction({txn: ptxn1, signer: sender})
-atc.addTransaction({txn: ptxn2, signer: sender})
+atc.addTransaction({txn: ptxn1, signer: signer})
+atc.addTransaction({txn: ptxn2, signer: signer})
 
 const result = await algokit.sendAtomicTransactionComposer({atc:atc, sendParams: {suppressLog:true}}, algodClient)
 console.log(`The first payment transaction sent ${result.transactions[0].amount} microAlgos and the second payment transaction sent ${result.transactions[1].amount} microAlgos`)

--- a/challenge/index.ts
+++ b/challenge/index.ts
@@ -45,8 +45,8 @@ const ptxn2 = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
 const signer = algokit.getSenderTransactionSigner(sender)
 
 const atc = new algosdk.AtomicTransactionComposer()
-atc.addTransaction({txn: ptxn1, signer: signer})
-atc.addTransaction({txn: ptxn2, signer: signer})
+atc.addTransaction({txn: ptxn1, signer})
+atc.addTransaction({txn: ptxn2, signer})
 
 const result = await algokit.sendAtomicTransactionComposer({atc:atc, sendParams: {suppressLog:true}}, algodClient)
 console.log(`The first payment transaction sent ${result.transactions[0].amount} microAlgos and the second payment transaction sent ${result.transactions[1].amount} microAlgos`)


### PR DESCRIPTION
## Fix the Bug Submission Pull Request

**What was the bug?**

The `addTransaction` method adds a single transaction to an atomic transaction group, it requires the transaction object as well as the TransactionSigner function. The TransactionSigner function is in turn responsible for signing transactions from the atomic transaction group. In this case, instead of passing the TransactionSigner function, the sender's account was passed and consequently, an error was raised with the message `TypeError: signer is not a function` and upon further inspection of the code you should see the typing error reported as `Type 'Account' is not assignable to type 'TransactionSigner'`.

**How did you fix the bug?**

The solution is to replace the sender object with a `TransactionSigner` method. The method can be created by either using the `makeBasicAccountTransactionSigner` funciton from `algosdk` or preferrably the `getSenderTransactionSigner` function from the `algokit` package and passing the `sender` Account object to either functions. In this case, `getSenderTransactionSigner` is preferred since it uses memoization and would be the optimal option if the `TransactionSigner` method has to be created multiple times for the same sender.

**Console Screenshot:**

![image](https://github.com/algorand-coding-challenges/challenge-4/assets/40172652/3a11c230-62c2-4e58-8700-f0a54c50dfe3)