### PR TITLE
Challenge-4 Solved

### DIFF
--- a/challenge/index.ts
+++ b/challenge/index.ts
@@ -43,8 +43,9 @@ const ptxn2 = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
 });
 
 const atc = new algosdk.AtomicTransactionComposer()
-atc.addTransaction({txn: ptxn1, signer: sender})
-atc.addTransaction({txn: ptxn2, signer: sender})
+const signerSender = algosdk.makeBasicAccountTransactionSigner(sender);
+atc.addTransaction({txn: ptxn1, signer: signerSender})
+atc.addTransaction({txn: ptxn2, signer: signerSender})
 
 const result = await algokit.sendAtomicTransactionComposer({atc:atc, sendParams: {suppressLog:true}}, algodClient)
 console.log(`The first payment transaction sent ${result.transactions[0].amount} microAlgos and the second payment transaction sent ${result.transactions[1].amount} microAlgos`)


### PR DESCRIPTION
## Fix the Bug Submission Pull Request

What was the bug?
-The two atomic transactions were not signed because a signer object was not given to them when being added to the atomic transaction composer.
- An algosdk.Account object was incorrectly used instead.


How did you fix the bug?
Solution: 
Created a signer object algosdk.TransactionSigner for the sender account with:
const signerSender = algosdk.makeBasicAccountTransactionSigner(sender)
and then gave the created signer to the addTransaction calls as:

atc.addTransaction({txn: ptxn1, signer: signerSender})
atc.addTransaction({txn: ptxn2, signer: signerSender})

**Console Screenshot:**

![Screenshot 2024-03-27 184523](https://github.com/algorand-coding-challenges/challenge-4/assets/149577768/ecf505cd-0cff-47ac-bcdf-9fdc08114df2)
