### PR TITLE
solved challenge 4

### DIFF
--- a/challenge/index.ts
+++ b/challenge/index.ts
@@ -43,8 +43,9 @@ const ptxn2 = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
 });
 
 const atc = new algosdk.AtomicTransactionComposer()
-atc.addTransaction({txn: ptxn1, signer: sender})
-atc.addTransaction({txn: ptxn2, signer: sender})
+const signer = algosdk.makeBasicAccountTransactionSigner(sender)
+atc.addTransaction({txn: ptxn1, signer: signer})
+atc.addTransaction({txn: ptxn2, signer: signer})
 
 const result = await algokit.sendAtomicTransactionComposer({atc:atc, sendParams: {suppressLog:true}}, algodClient)
 console.log(`The first payment transaction sent ${result.transactions[0].amount} microAlgos and the second payment transaction sent ${result.transactions[1].amount} microAlgos`)


### PR DESCRIPTION
## Fix the Bug Submission Pull Request

**What was the bug?**
while adding transactions to atomic transaction composer, we should pass a signer instance with transaction for signing the 
transaction, where here the account instance is being sent to the atc.

**How did you fix the bug?**
i have created a basicTransactionSigner using makeBasicAccountTransactionSigner() and passed it with transactions that are being passed into atc

**Console Screenshot:**

![image](https://github.com/algorand-coding-challenges/challenge-4/assets/110321560/cbea6c8e-bb85-48d9-8358-022672a7013a)