### PR TITLE
Fix: Sign transactions with a TransactionSigner object

### DIFF
--- a/challenge/index.ts
+++ b/challenge/index.ts
@@ -8,33 +8,22 @@ const algodClient = algokit.getAlgoClient()
 const sender = await algokit.getLocalNetDispenserAccount(algodClient)
 
 const receiver = await algokit.mnemonicAccountFromEnvironment(
-    {name: 'RECEIVER', fundWith: algokit.algos(100)},
+    { name: 'RECEIVER', fundWith: algokit.algos(100) },
     algodClient,
-  )
+)
 
-/*
-TODO: edit code below
-
-Description: 
-The below code is trying to atomically send 2 payment from sender to receiver 
-account by grouping them into an atomic transaction composer. 
-However, the code is not working. find and fix the bug so that the 2 payments are 
-successfully sent atomically.
-
-When solved correctly, the console should print out the following:
-"The first payment transaction sent 1000000 microAlgos and the second payment transaction sent 2000000 microAlgos"
-*/
-
+// Create the first payment transaction
 const suggestedParams = await algodClient.getTransactionParams().do();
 const ptxn1 = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
     from: sender.addr,
     suggestedParams,
     to: receiver.addr,
-    amount: 1000000,// 1 ALGO
+    amount: 1000000, // 1 ALGO
 });
 
 /// <reference lib="dom" />
 
+// Create the second payment transaction
 const ptxn2 = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
     from: sender.addr,
     suggestedParams,
@@ -42,10 +31,15 @@ const ptxn2 = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
     amount: 2000000, // 2 ALGOs
 });
 
-const atc = new algosdk.AtomicTransactionComposer()
-atc.addTransaction({txn: ptxn1, signer: sender})
-atc.addTransaction({txn: ptxn2, signer: sender})
+// Create signer for the Atomic Transaction
+const signer = algosdk.makeBasicAccountTransactionSigner(sender)
 
-const result = await algokit.sendAtomicTransactionComposer({atc:atc, sendParams: {suppressLog:true}}, algodClient)
+// Compose the Atomic Transaction
+const atc = new algosdk.AtomicTransactionComposer()
+atc.addTransaction({ txn: ptxn1, signer: signer })
+atc.addTransaction({ txn: ptxn2, signer: signer })
+
+// Send the Atomic Transaction
+const result = await algokit.sendAtomicTransactionComposer({ atc: atc, sendParams: { suppressLog: true } }, algodClient)
 console.log(`The first payment transaction sent ${result.transactions[0].amount} microAlgos and the second payment transaction sent ${result.transactions[1].amount} microAlgos`)
 


### PR DESCRIPTION
## Fix the Bug Submission Pull Request

**What was the bug?**

When composing the atomic transaction group, the transactions' `signer` parameters were incorrectly assigned to a standard `Account` object instead of a `TransactionSigner` object, which would had the capability to authorize the transactions.

This caused the following error to be thrown on `npm run start`:
```batch
> start
> tsx -r dotenv/config index.ts

LocalNet account 'RECEIVER' doesn't yet exist; created account 4DWMOO27DOLO53QKA43L46QIOOU6NOGQ6L23G5CNWNGY73VQZ6RFO542DI with keys stored in KMD and funding with 100 ALGOs
Transferring 100000000µALGOs from DASLV3YQ5M7F4APL3LJG5DWWTREJJRZIEE72W2TKPNLGD42AVVN3OHXY7Q to 4DWMOO27DOLO53QKA43L46QIOOU6NOGQ6L23G5CNWNGY73VQZ6RFO542DI
Received error executing Atomic Transaction Composer, for more information enable the debug flag TypeError: signer is not a function
    at <anonymous> (/developments/algorand-challenges/challenge-4/challenge/node_modules/algosdk/src/composer.ts:542:49)
    at Array.map (<anonymous>)
    at AtomicTransactionComposer.gatherSignatures (/developments/algorand-challenges/challenge-4/challenge/node_modules/algosdk/src/composer.ts:542:22)
    at AtomicTransactionComposer.submit (/developments/algorand-challenges/challenge-4/challenge/node_modules/algosdk/src/composer.ts:601:30)
    at AtomicTransactionComposer.execute (/developments/algorand-challenges/challenge-4/challenge/node_modules/algosdk/src/composer.ts:713:30)
    at Module.sendAtomicTransactionComposer (/developments/algorand-challenges/challenge-4/challenge/node_modules/@algorandfoundation/src/transaction/transaction.ts:557:30)
    at <anonymous> (/developments/algorand-challenges/challenge-4/challenge/index.ts:49:30)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
node:internal/process/esm_loader:40
      internalBinding('errors').triggerUncaughtException(
                                ^

TypeError: signer is not a function
    at <anonymous> (/developments/algorand-challenges/challenge-4/challenge/node_modules/algosdk/src/composer.ts:542:49)
    at Array.map (<anonymous>)
    at AtomicTransactionComposer.gatherSignatures (/developments/algorand-challenges/challenge-4/challenge/node_modules/algosdk/src/composer.ts:542:22)
    at AtomicTransactionComposer.submit (/developments/algorand-challenges/challenge-4/challenge/node_modules/algosdk/src/composer.ts:601:30)
    at AtomicTransactionComposer.execute (/developments/algorand-challenges/challenge-4/challenge/node_modules/algosdk/src/composer.ts:713:30)
    at Module.sendAtomicTransactionComposer (/developments/algorand-challenges/challenge-4/challenge/node_modules/@algorandfoundation/src/transaction/transaction.ts:557:30)
    at <anonymous> (/developments/algorand-challenges/challenge-4/challenge/index.ts:49:30)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
```

**How did you fix the bug?**

Before composing the atomic transaction group, a `TransactionSigner` object had to be initialized. 
Subsequently, this newly created `signer` had to be passed to sign both transactions.

```typescript
// Create signer for the Atomic Transaction
const signer = algosdk.makeBasicAccountTransactionSigner(sender)

// Compose the Atomic Transaction
const atc = new algosdk.AtomicTransactionComposer()
atc.addTransaction({ txn: ptxn1, signer: signer })
atc.addTransaction({ txn: ptxn2, signer: signer })
```

**Console Screenshot:**

<img width="623" alt="image" src="https://github.com/algorand-coding-challenges/challenge-4/assets/162426140/2eec08ee-9d31-4cb9-926a-21251fbda96b">