### PR TITLE
bug solved

### DIFF
--- a/challenge/index.ts
+++ b/challenge/index.ts
@@ -42,9 +42,11 @@ const ptxn2 = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
     amount: 2000000, // 2 ALGOs
 });
 
+const transaction_signer = algosdk.makeBasicAccountTransactionSigner(sender)
+
 const atc = new algosdk.AtomicTransactionComposer()
-atc.addTransaction({txn: ptxn1, signer: sender})
-atc.addTransaction({txn: ptxn2, signer: sender})
+atc.addTransaction({txn: ptxn1, signer: transaction_signer})
+atc.addTransaction({txn: ptxn2, signer: transaction_signer})
 
 const result = await algokit.sendAtomicTransactionComposer({atc:atc, sendParams: {suppressLog:true}}, algodClient)
 console.log(`The first payment transaction sent ${result.transactions[0].amount} microAlgos and the second payment transaction sent ${result.transactions[1].amount} microAlgos`)


### PR DESCRIPTION
## Fix the Bug Submission Pull Request

LocalNet account 'RECEIVER' doesn't yet exist; created account XROZ3LWYBDV7FI2OVPIHDQ7A4IPS3FLRHPCZ7ASYTXMHBKDQ7TBTZSNCBQ with keys stored in KMD and funding with 100 ALGOs
Transferring 100000000µALGOs from E5AV2M3D533DURD5VSBREWYDYP4IRKYVXHMAJIC63QVMACV3R6DEN5JLSI to XROZ3LWYBDV7FI2OVPIHDQ7A4IPS3FLRHPCZ7ASYTXMHBKDQ7TBTZSNCBQ
Received error executing Atomic Transaction Composer, for more information enable the debug flag TypeError: signer is not a function

<!-- Provide a clear and concise description of the bug. -->

**How did you fix the bug?**

I utilized the 'makeBasicAccountTransactionSigner' function with the 'sender' parameter to extract the 'signer' of type 'algosdk.TransactionSigner'. Subsequently, I provided the appropriate 'signer' type to the 'addTransaction' function.

**Console Screenshot:**

![image](https://github.com/algorand-coding-challenges/challenge-4/assets/67314024/51012e55-7e3c-44b4-a686-266e133f5ec4)