### PR TITLE
[Fix] Account used in place of a signer in addTransaction call.

### DIFF
--- a/challenge/index.ts
+++ b/challenge/index.ts
@@ -1,5 +1,5 @@
-import algosdk from "algosdk";
 import * as algokit from '@algorandfoundation/algokit-utils';
+import algosdk from "algosdk";
 
 // Set up algod client
 const algodClient = algokit.getAlgoClient()
@@ -43,8 +43,8 @@ const ptxn2 = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
 });
 
 const atc = new algosdk.AtomicTransactionComposer()
-atc.addTransaction({txn: ptxn1, signer: sender})
-atc.addTransaction({txn: ptxn2, signer: sender})
+atc.addTransaction({txn: ptxn1, signer: algosdk.makeBasicAccountTransactionSigner(sender)})
+atc.addTransaction({txn: ptxn2, signer: algosdk.makeBasicAccountTransactionSigner(sender)})
 
 const result = await algokit.sendAtomicTransactionComposer({atc:atc, sendParams: {suppressLog:true}}, algodClient)
 console.log(`The first payment transaction sent ${result.transactions[0].amount} microAlgos and the second payment transaction sent ${result.transactions[1].amount} microAlgos`)


### PR DESCRIPTION
## Fix the Bug Submission Pull Request

**What was the bug?**

The AtomicTransactionComposer::addTransaction method was call with the sender: Account as signer: TransactionSigner parameter.

**How did you fix the bug?**

I used algosdk.makeBasicAccountTransactionSigner to create a signer from the account and used it as signer parameter.

**Console Screenshot:**

![image](https://github.com/algorand-coding-challenges/challenge-4/assets/162464577/23ed41a5-6794-4a99-8d50-3b5a7e82b4ef)
