### PR TITLE
makeBasicAccountTransactionSigner

### DIFF
--- a/challenge/index.ts
+++ b/challenge/index.ts
@@ -1,4 +1,4 @@
-import algosdk from "algosdk";
+import algosdk, { makeBasicAccountTransactionSigner } from "algosdk";
 import * as algokit from '@algorandfoundation/algokit-utils';
 
 // Set up algod client
@@ -43,8 +43,9 @@ const ptxn2 = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
 });
 
 const atc = new algosdk.AtomicTransactionComposer()
-atc.addTransaction({txn: ptxn1, signer: sender})
-atc.addTransaction({txn: ptxn2, signer: sender})
+const sgn = makeBasicAccountTransactionSigner(sender)
+atc.addTransaction({txn: ptxn1, signer: sgn})
+atc.addTransaction({txn: ptxn2, signer: sgn})
 
 const result = await algokit.sendAtomicTransactionComposer({atc:atc, sendParams: {suppressLog:true}}, algodClient)
 console.log(`The first payment transaction sent ${result.transactions[0].amount} microAlgos and the second payment transaction sent ${result.transactions[1].amount} microAlgos`)


### PR DESCRIPTION
## Fix the Bug Submission Pull Request

**What was the bug?**

The Bug lies in the passing of the Sender as the parameter which returns an Account type but not a Signer.

**How did you fix the bug?**

Simple step is to create a new signer variable using the makeBasicAccountTransactionSigner(sender) method to get a basic signer for the Sender.

**Console Screenshot:**

![Screenshot 2024-03-28 220139](https://github.com/algorand-coding-challenges/challenge-4/assets/95990089/15063502-8b79-4aca-aa80-fc615cc8404d)
