### PR TITLE
Create signer from account

### DIFF
--- a/challenge/index.ts
+++ b/challenge/index.ts
@@ -42,9 +42,11 @@ const ptxn2 = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
     amount: 2000000, // 2 ALGOs
 });
 
+const signer = algosdk.makeBasicAccountTransactionSigner(sender);
+
 const atc = new algosdk.AtomicTransactionComposer()
-atc.addTransaction({txn: ptxn1, signer: sender})
-atc.addTransaction({txn: ptxn2, signer: sender})
+atc.addTransaction({txn: ptxn1, signer })
+atc.addTransaction({txn: ptxn2, signer })
 
 const result = await algokit.sendAtomicTransactionComposer({atc:atc, sendParams: {suppressLog:true}}, algodClient)
 console.log(`The first payment transaction sent ${result.transactions[0].amount} microAlgos and the second payment transaction sent ${result.transactions[1].amount} microAlgos`)


### PR DESCRIPTION
**What was the bug?**
While adding the two payment transactions to the atomic transaction composer, the sender's signer was not passed with the transactions. Instead, the sender's account was passed.

**How did you fix the bug?**
In order to fix the bug, I used algosdk's makeBasicAccountTransactionSigner method to create a signer from the sender's account. I passed the signer along with the transactions into the atomic transaction composer and voila! it worked.

**Console Screenshot:**
![image](https://github.com/algorand-coding-challenges/challenge-4/assets/68940073/8c08220f-92db-4882-84b8-1647656eb226)