### PR TITLE
Fix Challenge 4 🦞 

### DIFF
--- a/challenge/index.ts
+++ b/challenge/index.ts
@@ -42,9 +42,11 @@ const ptxn2 = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
     amount: 2000000, // 2 ALGOs
 });
 
+const senderTransactionSigner = algokit.getSenderTransactionSigner(sender)
+
 const atc = new algosdk.AtomicTransactionComposer()
-atc.addTransaction({txn: ptxn1, signer: sender})
-atc.addTransaction({txn: ptxn2, signer: sender})
+atc.addTransaction({txn: ptxn1, signer: senderTransactionSigner})
+atc.addTransaction({txn: ptxn2, signer: senderTransactionSigner})
 
 const result = await algokit.sendAtomicTransactionComposer({atc:atc, sendParams: {suppressLog:true}}, algodClient)
 console.log(`The first payment transaction sent ${result.transactions[0].amount} microAlgos and the second payment transaction sent ${result.transactions[1].amount} microAlgos`)


### PR DESCRIPTION
## Fix the Bug Submission Pull Request

**What was the bug?**

When adding atomic transactions the signer parameter was sent as an Account when it needs a TransactionSigner.

**How did you fix the bug?**

By reading the documentation I have found a method to get the Transaction Signer from the Account.
https://github.com/algorandfoundation/algokit-utils-ts/blob/main/docs/capabilities/transaction.md#signing
Therefore, I have updated the code to fix the issue.

```typescript
const senderTransactionSigner = algokit.getSenderTransactionSigner(sender)

const atc = new algosdk.AtomicTransactionComposer()
atc.addTransaction({txn: ptxn1, signer: senderTransactionSigner})
atc.addTransaction({txn: ptxn2, signer: senderTransactionSigner})

```

**Console Screenshot:**

<img width="967" alt="Captura de pantalla 2024-03-29 a las 10 35 42" src="https://github.com/algorand-coding-challenges/challenge-4/assets/56583038/58362b96-be9a-4e3c-9e3d-5058969744a1">
