### PR TITLE
Fixed transaction signer

### DIFF
--- a/challenge/index.ts
+++ b/challenge/index.ts
@@ -6,6 +6,7 @@ const algodClient = algokit.getAlgoClient()
 
 // Retrieve 2 accounts from localnet kmd
 const sender = await algokit.getLocalNetDispenserAccount(algodClient)
+const signer = algosdk.makeBasicAccountTransactionSigner(sender)
 
 const receiver = await algokit.mnemonicAccountFromEnvironment(
     {name: 'RECEIVER', fundWith: algokit.algos(100)},
@@ -43,8 +44,8 @@ const ptxn2 = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
 });
 
 const atc = new algosdk.AtomicTransactionComposer()
-atc.addTransaction({txn: ptxn1, signer: sender})
-atc.addTransaction({txn: ptxn2, signer: sender})
+atc.addTransaction({txn: ptxn1, signer})
+atc.addTransaction({txn: ptxn2, signer})
 
 const result = await algokit.sendAtomicTransactionComposer({atc:atc, sendParams: {suppressLog:true}}, algodClient)
 console.log(`The first payment transaction sent ${result.transactions[0].amount} microAlgos and the second payment transaction sent ${result.transactions[1].amount} microAlgos`)


### PR DESCRIPTION
## Fix the Bug Submission Pull Request

**What was the bug?**
For both send transactions, the sender account object was being passed to the transaction as the signer instead of a `TransactionSigner` instance of the sender account.

<!-- Provide a clear and concise description of the bug. -->

**How did you fix the bug?**
I created a `TransactionSigner` instance of the sender account and passed it to both transactions.

<!-- Explain the steps you took to fix the bug. -->
I used the `makeBasicAccountTransactionSigner` method of the algosdk to create a `TransactionSigner` instance of the sender account, which I then used to replace the invalid signer argument that was passed to both transactions.

**Console Screenshot:**
![Screenshot from 2024-03-31 17-56-54](https://github.com/algorand-coding-challenges/challenge-4/assets/69152671/1749f3b4-0843-4041-b924-620cd0e514e4)

<!-- Attach a screenshot of your console showing the result specified in the README. -->