### PR TITLE
index.ts lines 46 and 47: Changed second parameter in addTransaction calls to makeBasicAccountTransactionSigner(signer) instead of just sender

### DIFF
--- a/challenge/index.ts
+++ b/challenge/index.ts
@@ -43,8 +43,8 @@ const ptxn2 = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
 });
 
 const atc = new algosdk.AtomicTransactionComposer()
-atc.addTransaction({txn: ptxn1, signer: sender})
-atc.addTransaction({txn: ptxn2, signer: sender})
+atc.addTransaction({txn: ptxn1, signer: algosdk.makeBasicAccountTransactionSigner(sender)})
+atc.addTransaction({txn: ptxn2, signer: algosdk.makeBasicAccountTransactionSigner(sender)})
 
 const result = await algokit.sendAtomicTransactionComposer({atc:atc, sendParams: {suppressLog:true}}, algodClient)
 console.log(`The first payment transaction sent ${result.transactions[0].amount} microAlgos and the second payment transaction sent ${result.transactions[1].amount} microAlgos`)


### PR DESCRIPTION
1. The code for coding challenge #4 is failing with the error `TypeError: signer is not a function`
2. On lines 46 and 47 of the original code, `sender`, an account object, is being used as the second parameter for the `addTransaction` call. This parameter needs to be a signer object. The algo SDK function `makeBasicAccountTransactionSigner` can be used to get the signer for the sender object (in other words, the second parameter in both calls should be changed to `algosdk.makeBasicAccountTransactionSigner(sender)`). 
3. 
![Screenshot from 2024-04-01 06-58-20](https://github.com/algorand-coding-challenges/challenge-4/assets/8784896/143afbeb-102c-4835-81a5-337bfc5aab8c)
