### PR TITLE
fix: fixed the challenge 4 bug

### DIFF
--- a/challenge/index.ts
+++ b/challenge/index.ts
@@ -1,16 +1,16 @@
 import algosdk from "algosdk";
-import * as algokit from '@algorandfoundation/algokit-utils';
+import * as algokit from "@algorandfoundation/algokit-utils";
 
 // Set up algod client
-const algodClient = algokit.getAlgoClient()
+const algodClient = algokit.getAlgoClient();
 
 // Retrieve 2 accounts from localnet kmd
-const sender = await algokit.getLocalNetDispenserAccount(algodClient)
+const sender = await algokit.getLocalNetDispenserAccount(algodClient);
 
 const receiver = await algokit.mnemonicAccountFromEnvironment(
-    {name: 'RECEIVER', fundWith: algokit.algos(100)},
-    algodClient,
-  )
+  { name: "RECEIVER", fundWith: algokit.algos(100) },
+  algodClient
+);
 
 /*
 TODO: edit code below
@@ -27,25 +27,31 @@ When solved correctly, the console should print out the following:
 
 const suggestedParams = await algodClient.getTransactionParams().do();
 const ptxn1 = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
-    from: sender.addr,
-    suggestedParams,
-    to: receiver.addr,
-    amount: 1000000,// 1 ALGO
+  from: sender.addr,
+  suggestedParams,
+  to: receiver.addr,
+  amount: 1000000, // 1 ALGO
 });
 
 /// <reference lib="dom" />
 
 const ptxn2 = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
-    from: sender.addr,
-    suggestedParams,
-    to: receiver.addr,
-    amount: 2000000, // 2 ALGOs
+  from: sender.addr,
+  suggestedParams,
+  to: receiver.addr,
+  amount: 2000000, // 2 ALGOs
 });
 
-const atc = new algosdk.AtomicTransactionComposer()
-atc.addTransaction({txn: ptxn1, signer: sender})
-atc.addTransaction({txn: ptxn2, signer: sender})
+const senderSigner = algosdk.makeBasicAccountTransactionSigner(sender);
 
-const result = await algokit.sendAtomicTransactionComposer({atc:atc, sendParams: {suppressLog:true}}, algodClient)
-console.log(`The first payment transaction sent ${result.transactions[0].amount} microAlgos and the second payment transaction sent ${result.transactions[1].amount} microAlgos`)
+const atc = new algosdk.AtomicTransactionComposer();
+atc.addTransaction({ txn: ptxn1, signer: senderSigner });
+atc.addTransaction({ txn: ptxn2, signer: senderSigner });
 
+const result = await algokit.sendAtomicTransactionComposer(
+  { atc: atc, sendParams: { suppressLog: true } },
+  algodClient
+);
+console.log(
+  `The first payment transaction sent ${result.transactions[0].amount} microAlgos and the second payment transaction sent ${result.transactions[1].amount} microAlgos`
+);


### PR DESCRIPTION
## Fix the Bug Submission Pull Request

**What was the bug?**

The bug was trying to group two automatically payment transactions and send them using atomic transfers but passing the wrong value to the signer when adding the transaction. The sender account was being passed instead of the signer and that triggered the bug of Account not assignable to Transaction signer

**How did you fix the bug?**

I created an account signer for the sender account on line 45 and then passed that signer value to the signer instead of passing the sender's account.

**Console Screenshot:**

<!-- Attach a screenshot of your console showing the result specified in the README. -->
<img width="1440" alt="Screenshot 2024-04-01 at 13 25 03" src="https://github.com/algorand-coding-challenges/challenge-4/assets/41029959/2b1cef1d-0489-48b0-8364-7b4dfe1ba683">
