### PR TITLE
Solved: Algorand Challenge 4

### DIFF
--- a/challenge/index.ts
+++ b/challenge/index.ts
@@ -1,4 +1,4 @@
-import algosdk from "algosdk";
+import algosdk, { makeBasicAccountTransactionSigner } from "algosdk";
 import * as algokit from '@algorandfoundation/algokit-utils';
 
 // Set up algod client
@@ -42,9 +42,11 @@ const ptxn2 = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
     amount: 2000000, // 2 ALGOs
 });
 
+const senderTxnSigner: algosdk.TransactionSigner = makeBasicAccountTransactionSigner(sender);
+
 const atc = new algosdk.AtomicTransactionComposer()
-atc.addTransaction({txn: ptxn1, signer: sender})
-atc.addTransaction({txn: ptxn2, signer: sender})
+atc.addTransaction({txn: ptxn1, signer: senderTxnSigner})
+atc.addTransaction({txn: ptxn2, signer: senderTxnSigner})
 
 const result = await algokit.sendAtomicTransactionComposer({atc:atc, sendParams: {suppressLog:true}}, algodClient)
 console.log(`The first payment transaction sent ${result.transactions[0].amount} microAlgos and the second payment transaction sent ${result.transactions[1].amount} microAlgos`)


### PR DESCRIPTION
## Fix the Bug Submission Pull Request

**What was the bug?**

<!-- Provide a clear and concise description of the bug. -->
The bug was about the fact that the "addTransaction" method of the "AtomicTransactionComposer" class couldn't take the sender Account as an argument to sign the transactions in the atomic transactions group because the sender is of type "Account" while It takes as argument an object of type "TransactionSigner". The latter is what's needed to sign every transaction added in the atomic transfers transactions group.

**How did you fix the bug?**

<!-- Explain the steps you took to fix the bug. -->
I fixed the bug by applying the function "makeBasicAccountTransactionSigner" on the sender Account, so I created an object of type "TransactionSigner" (this type represents a function which can sign transactions from an atomic transaction group) and then I used this object to sign the two transactions in the atomic transaction group.

**Console Screenshot:**

<!-- Attach a screenshot of your console showing the result specified in the README. -->
![image](https://github.com/algorand-coding-challenges/challenge-4/assets/55320885/bf2002bb-1c4f-44ea-b205-8b86ae4df450)
