### PR TITLE
type for signer was incorrect when adding both transactions.

### DIFF
--- a/challenge/index.ts
+++ b/challenge/index.ts
@@ -43,8 +43,8 @@ const ptxn2 = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
 });
 
 const atc = new algosdk.AtomicTransactionComposer()
-atc.addTransaction({txn: ptxn1, signer: sender})
-atc.addTransaction({txn: ptxn2, signer: sender})
+atc.addTransaction({txn: ptxn1, signer: algokit.getSenderTransactionSigner(sender)})
+atc.addTransaction({txn: ptxn2, signer: algokit.getSenderTransactionSigner(sender)})
 
 const result = await algokit.sendAtomicTransactionComposer({atc:atc, sendParams: {suppressLog:true}}, algodClient)
 console.log(`The first payment transaction sent ${result.transactions[0].amount} microAlgos and the second payment transaction sent ${result.transactions[1].amount} microAlgos`)


### PR DESCRIPTION
## Fix the Bug Submission Pull Request

**What was the bug?**

When signing the transactions the incorrect object was being passedd as the signer.

**How did you fix the bug?**

Use the algokit getSenderTransactionsSigner method to provide the correct object.

![image](https://github.com/algorand-coding-challenges/challenge-4/assets/4723326/3f803327-c5e4-49ea-b571-366a97d638f7)

<!-- Attach a screenshot of your console showing the result specified in the README. -->