### PR TITLE
Fix signer in atomic group additions

### DIFF
--- a/challenge/index.ts
+++ b/challenge/index.ts
@@ -42,9 +42,10 @@ const ptxn2 = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
     amount: 2000000, // 2 ALGOs
 });
 
+const signer = algosdk.makeBasicAccountTransactionSigner(sender)
 const atc = new algosdk.AtomicTransactionComposer()
-atc.addTransaction({txn: ptxn1, signer: sender})
-atc.addTransaction({txn: ptxn2, signer: sender})
+atc.addTransaction({txn: ptxn1, signer: signer})
+atc.addTransaction({txn: ptxn2, signer: signer})
 
 const result = await algokit.sendAtomicTransactionComposer({atc:atc, sendParams: {suppressLog:true}}, algodClient)
 console.log(`The first payment transaction sent ${result.transactions[0].amount} microAlgos and the second payment transaction sent ${result.transactions[1].amount} microAlgos`)


### PR DESCRIPTION
## Fix the Bug Submission Pull Request

**What was the bug?**
Creation of atomic group of two payment transactions using Atomic Transaction Composer resulted in `TypeError: signer is not a function` error on transaction addition. It happened because during the creation of `TransactionWithSigner` object expected in `addTransaction` function sender account was incorrectly passed instead of its signer.

**How did you fix the bug?**
The bug was fixed by creation of proper signer object for sender account and by passing it instead of account itself.

**Console Screenshot:**

![challenge4](https://github.com/algorand-coding-challenges/challenge-4/assets/114208957/42c577dc-c679-4749-8ffb-bd47893f1469)