### PR TITLE
fix: addTransaction signer

### DIFF
--- a/challenge/index.ts
+++ b/challenge/index.ts
@@ -42,9 +42,12 @@ const ptxn2 = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
     amount: 2000000, // 2 ALGOs
 });
 
+// Make transaction signer to add to addTransation as signer
+const signer = algosdk.makeBasicAccountTransactionSigner(sender)
+
 const atc = new algosdk.AtomicTransactionComposer()
-atc.addTransaction({txn: ptxn1, signer: sender})
-atc.addTransaction({txn: ptxn2, signer: sender})
+atc.addTransaction({txn: ptxn1, signer: signer})
+atc.addTransaction({txn: ptxn2, signer: signer})
 
 const result = await algokit.sendAtomicTransactionComposer({atc:atc, sendParams: {suppressLog:true}}, algodClient)
 console.log(`The first payment transaction sent ${result.transactions[0].amount} microAlgos and the second payment transaction sent ${result.transactions[1].amount} microAlgos`)


### PR DESCRIPTION
## Fix the Bug Submission Pull Request

**What was the bug?**

The bug was that the addTransation calls were receiving sender Account object instead of a TransactionSigner object 

**How did you fix the bug?**

I have fixed the bug by calling makeBasicAccountTransactionSigner and passing the sender account and then storing the result on a const and passing as signer param into addTransaction method.

**Console Screenshot:**

<img width="1080" alt="Screenshot 2024-04-07 at 12 10 36" src="https://github.com/algorand-coding-challenges/challenge-4/assets/57917137/444bf337-3d15-4faa-a157-3499fcaea792">
