### PR TITLE
Correct signer

### DIFF
--- a/challenge/index.ts
+++ b/challenge/index.ts
@@ -43,8 +43,8 @@ const ptxn2 = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
 });
 
 const atc = new algosdk.AtomicTransactionComposer()
-atc.addTransaction({txn: ptxn1, signer: sender})
-atc.addTransaction({txn: ptxn2, signer: sender})
+atc.addTransaction({txn: ptxn1, signer: algokit.getSenderTransactionSigner(sender)})
+atc.addTransaction({txn: ptxn2, signer: algokit.getSenderTransactionSigner(sender)})
 
 const result = await algokit.sendAtomicTransactionComposer({atc:atc, sendParams: {suppressLog:true}}, algodClient)
 console.log(`The first payment transaction sent ${result.transactions[0].amount} microAlgos and the second payment transaction sent ${result.transactions[1].amount} microAlgos`)


### PR DESCRIPTION
## Fix the Bug Submission Pull Request

**What was the bug?**

The signers were not submitted to the atomic transaction composer in the appropriate format.

**How did you fix the bug?**

I used "algokit.getSenderTransactionSigner(sender)" to retrieve the corresponding signer for the sender account.

**Console Screenshot:**

<img width="570" alt="Screenshot 2024-04-07 at 21 34 20" src="https://github.com/algorand-coding-challenges/challenge-4/assets/35114953/605c289a-eb4f-4ad1-a852-23b37daacfb6">
