### PR TITLE
Fix atc transaction signers

### DIFF
--- a/challenge/index.ts
+++ b/challenge/index.ts
@@ -43,8 +43,8 @@ const ptxn2 = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
 });
 
 const atc = new algosdk.AtomicTransactionComposer()
-atc.addTransaction({txn: ptxn1, signer: sender})
-atc.addTransaction({txn: ptxn2, signer: sender})
+atc.addTransaction({txn: ptxn1, signer: algokit.getSenderTransactionSigner(sender)})
+atc.addTransaction({txn: ptxn2, signer: algokit.getSenderTransactionSigner(sender)})
 
 const result = await algokit.sendAtomicTransactionComposer({atc:atc, sendParams: {suppressLog:true}}, algodClient)
 console.log(`The first payment transaction sent ${result.transactions[0].amount} microAlgos and the second payment transaction sent ${result.transactions[1].amount} microAlgos`)


### PR DESCRIPTION
## Fix the Bug Submission Pull Request

**What was the bug?**

Transactions added to atomic transfer composer were missing valid signers

**How did you fix the bug?**

Use the getSenderTxSigner to get the signer, and add that to the transaction

**Console Screenshot:**
 
<img width="803" alt="Screen Shot 2024-04-09 at 9 35 13 PM" src="https://github.com/algorand-coding-challenges/challenge-4/assets/707142/30502885-844b-4207-96ef-a20a34f838f6">
