### PR TITLE
Fixed the issue

### DIFF
--- a/challenge/index.ts
+++ b/challenge/index.ts
@@ -5,7 +5,7 @@ import * as algokit from '@algorandfoundation/algokit-utils';
 const algodClient = algokit.getAlgoClient()
 
 // Retrieve 2 accounts from localnet kmd
-const sender = await algokit.getLocalNetDispenserAccount(algodClient)
+const sender = await algokit.getLocalNetDispenserAccount(algodClient);
 
 const receiver = await algokit.mnemonicAccountFromEnvironment(
     {name: 'RECEIVER', fundWith: algokit.algos(100)},
@@ -28,23 +28,25 @@ When solved correctly, the console should print out the following:
 const suggestedParams = await algodClient.getTransactionParams().do();
 const ptxn1 = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
     from: sender.addr,
-    suggestedParams,
     to: receiver.addr,
     amount: 1000000,// 1 ALGO
+    suggestedParams,
 });
 
-/// <reference lib="dom" />
+// / <reference lib="dom" />
 
 const ptxn2 = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
     from: sender.addr,
-    suggestedParams,
     to: receiver.addr,
     amount: 2000000, // 2 ALGOs
+    suggestedParams,
 });
 
 const atc = new algosdk.AtomicTransactionComposer()
-atc.addTransaction({txn: ptxn1, signer: sender})
-atc.addTransaction({txn: ptxn2, signer: sender})
+
+atc.addTransaction({ txn: ptxn1, signer: algosdk.makeBasicAccountTransactionSigner(sender) });
+// atc.addTransaction({txn: ptxn2, signer: sender});
+atc.addTransaction({ txn: ptxn2, signer: algosdk.makeBasicAccountTransactionSigner(sender) });
 
 const result = await algokit.sendAtomicTransactionComposer({atc:atc, sendParams: {suppressLog:true}}, algodClient)
 console.log(`The first payment transaction sent ${result.transactions[0].amount} microAlgos and the second payment transaction sent ${result.transactions[1].amount} microAlgos`)


### PR DESCRIPTION
## Fix the Bug Submission Pull Request

**What was the bug?**

The issue comes from the transaction composer, each transaction requires a signer.
`// atc.addTransaction({txn: ptxn2, signer: sender});`

**How did you fix the bug?**
By adding a Basic Transaction signer with the transaction as sender object, to sign off the transaction.
Ex: `atc.addTransaction({ txn: ptxn2, signer: algosdk.makeBasicAccountTransactionSigner(sender) });`


**Console Screenshot:**

<img width="522" alt="Screenshot 2024-04-09 at 15 33 04" src="https://github.com/algorand-coding-challenges/challenge-4/assets/43073157/8ecd18eb-68a1-4f79-be04-eb6434331b98">
