### PR TITLE
Made the fix to create the atomic transaction.

### DIFF
--- a/challenge/index.ts
+++ b/challenge/index.ts
@@ -42,9 +42,14 @@ const ptxn2 = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
     amount: 2000000, // 2 ALGOs
 });
 
-const atc = new algosdk.AtomicTransactionComposer()
-atc.addTransaction({txn: ptxn1, signer: sender})
-atc.addTransaction({txn: ptxn2, signer: sender})
+const atc = new algosdk.AtomicTransactionComposer();
+//atc.addTransaction({txn: ptxn1, signer: sender})
+//atc.addTransaction({txn: ptxn2, signer: sender})
+//const signer1 = algokit.signTransaction(ptxn1, sender); //({sender.sk})
+const signer1 = await algokit.getTransactionWithSigner(ptxn1, sender);
+const signer2 = await algokit.getTransactionWithSigner(ptxn2, sender);
+atc.addTransaction(signer1);
+atc.addTransaction(signer2);
 
 const result = await algokit.sendAtomicTransactionComposer({atc:atc, sendParams: {suppressLog:true}}, algodClient)
 console.log(`The first payment transaction sent ${result.transactions[0].amount} microAlgos and the second payment transaction sent ${result.transactions[1].amount} microAlgos`)


### PR DESCRIPTION
## Fix the Bug Submission Pull Request

**What was the bug?**

The bug was that the two transactions were not being signed, and that TransactionWithSigner was not being passed to the atc.addTransaction method. 

**How did you fix the bug?**

I used the getTransactionWithSigner method, evoked it two times, once for each transaction. Signed it with the sender account, and then added the transaction to the atomic transaction composer.

**Console Screenshot:**

![image](https://github.com/algorand-coding-challenges/challenge-4/assets/122029405/3d6a54f5-40b0-40d8-a93e-f7993ea3bf84)